### PR TITLE
Better handling of transactions

### DIFF
--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -158,6 +158,7 @@ class ConnectionTest extends TestCase
             $mock->throwOnQuery('(not a connection issue)');
             $connection->beginTransaction();
             $connection->runQuery('select * from users');
+            $this->assertTrue(false, 'runQuery did not throw an exception');
         } catch (PDOException $exception) {
             // (We just want to suppress this.)
         }


### PR DESCRIPTION
The problem: If a retry occurs mid-transaction, data integrity could be compromised.

e.g. Imagine the following transaction:

```
$connection->beginTransaction();

$connection->runQuery('INSERT INTO `users` ...');
$connection->runQuery('UPDATE `tracking` ...');
$connection->runQuery('INSERT INTO `something_else` ...');
$connection->runQuery('INSERT INTO `etc` ...');

$connection->commit();
```

The intention is that all 4 of these queries must be atomic. However, if a connection error occurs after the second query, the transaction will be aborted, but the following two queries will still be executed i.e. only half of the "atomic" operation would be completed.

This PR (hopefully) improves the handling of transactions.

(I've known about this issue for a long time, but transactions have never been used in App - until now that I'm likely to need to use transactions as part of an issue I'm working on - so this should probably be fixed.)