### PR TITLE
chore: bump phpunit/phpunit to ^9.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "illuminate/database": "^8.5 || ^9.0 || ^10.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "phpstan/phpstan": "^0.12.99",
         "symfony/var-dumper": "^5.3",
         "friendsofphp/php-cs-fixer": "^3.1"


### PR DESCRIPTION
## pdo-retry-wrapper

- Target: `phpunit/phpunit:^9.6` (dev)
- Audit config changes: None
- Commands executed:
  - `docker compose up -d`
  - `rm -f composer.lock`
  - `docker compose exec -T project composer update --with-all-dependencies`
  - `docker compose exec -T project composer require --dev phpunit/phpunit:^9.6 -W`
  - `docker compose exec -T project ./vendor/bin/phpunit --testdox tests`
- Test results: ✅ `OK (14 tests, 33 assertions)` (phpstan failed, but phpunit passed)
- Status: ✅ Complete (PR: https://github.com/ihasco/pdo-retry-wrapper/pull/6)